### PR TITLE
Usar BytesIO ao inves de StringIO no Python3.

### DIFF
--- a/portpy/codec/register.py
+++ b/portpy/codec/register.py
@@ -7,10 +7,10 @@ from ..portpy import Language
 
 try:
     # Python 2
-    from cStringIO import StringIO
+    from cStringIO import StringIO as BytesIO
 except ImportError:
     # Python 3
-    from io import StringIO
+    from io import BytesIO
 
 
 def search_function(encoding):
@@ -26,7 +26,7 @@ def search_function(encoding):
     def portpy_decode(input, errors='strict'):
         if isinstance(input, memoryview):
             input = input.tobytes()
-        input = StringIO(input).read()
+        input = BytesIO(input).read()
         return utf8.decode(lang.translate(input), errors)
 
     class PortpyIncrementalDecoder(utf_8.IncrementalDecoder):


### PR DESCRIPTION
A função importlib.utils.decode_source do Python 3.4 estava falhando com o PortPy quando eu passava bytes ao inves de str.
Mudei StringIO para BytesIO e parece que tudo continua funcionando (mesmo passando unicode).

Issue relacionada: https://github.com/JoaoFelipe/pyposast/issues/1
